### PR TITLE
feat: get transitions based on names from API

### DIFF
--- a/bin/ja
+++ b/bin/ja
@@ -84,50 +84,59 @@ open_ticket() {
 }
 
 # 1: Ticket Key (eg. TICKET-123)
-# 2: Transition ID (eg. 71)
-# 3: Transition string (eg. IN PROGRESS)
+# 2: Transition string (eg. In Progress)
 transition_ticket() {
-  focused_ticket=$(get_focused_ticket "$1" "mp")
+  local api_endpoint response transition_id JSON_DATA transition_ids_response
+  api_endpoint="$JIRA_URL/rest/api/2/issue/$1/transitions"
+  transition_ids_response=$(curl -s -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/json" "${api_endpoint}")
+  transition_id=$(echo "$transition_ids_response" | jq -r --arg search_name "$2" '.transitions[] | select(.name == $search_name) | .id')
 
-  # TODO: Transition IDs should be configurable
+  if [ -z "$transition_id" ] || [ "$transition_id" == "null" ]; then
+    echo $(red "Can't find transition for ticket with name $2 for ticket: $1")
+    exit 1
+  fi
 
   JSON_DATA=$(
     cat <<EOF
 {
   "transition": {
-    "id": "$2"
+    "id": "$transition_id"
   }
 }
 EOF
   )
 
   # Send the API request to move the ticket
-  response=$(curl -s -X POST \
+  curl -s -X POST \
     -H "Authorization: Bearer $ACCESS_TOKEN" \
     -H "Content-Type: application/json" \
-    --data "$JSON_DATA" "$JIRA_URL/rest/api/2/issue/$focused_ticket/transitions")
+    --data "$JSON_DATA" "$JIRA_URL/rest/api/2/issue/$1/transitions"
 
-  echo $(green "Moved $focused_ticket -> $3")
+  echo $(green "Moved $1 -> In Progress")
 }
 
 move_todo() {
-  TRANSITION_TODO="21"
-  transition_ticket "$1" "$TRANSITION_TODO" "TODO"
+  local focused_ticket transition_id
+  focused_ticket=$(get_focused_ticket "$1" "mt")
+  transition_ticket "$focused_ticket" "To do"
 }
 
 move_in_progress() {
-  TRANSITION_IN_PROGRESS="71"
-  transition_ticket "$1" "$TRANSITION_IN_PROGRESS" "IN PROGRESS"
+  local focused_ticket transition_id
+  focused_ticket=$(get_focused_ticket "$1" "mt")
+  transition_ticket "$focused_ticket" "In Progress"
 }
 
 move_review() {
-  TRANSITION_IN_PROGRESS="91"
-  transition_ticket "$1" "$TRANSITION_IN_PROGRESS" "REVIEW"
+  local focused_ticket transition_id
+  focused_ticket=$(get_focused_ticket "$1" "mt")
+  transition_ticket "$focused_ticket" "Review"
 }
 
 move_done() {
-  TRANSITION_DONE="141"
-  transition_ticket "$1" "$TRANSITION_DONE" "DONE"
+  local focused_ticket transition_id
+  focused_ticket=$(get_focused_ticket "$1" "mt")
+  transition_ticket "$focused_ticket" "Done"
 }
 
 focus_on_ticket() {


### PR DESCRIPTION
should GET transitions from the jira instance not define locally

should make things more robust